### PR TITLE
Dockerfile mage code path to python path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ RUN pip3 install -r ${USER_CODE_PATH}/requirements.txt
 # Install custom libraries within 3rd party libraries (e.g. DBT packages)
 RUN python3 /app/install_other_dependencies.py --path ${USER_CODE_PATH}
 
-ENV PYTHONPATH="${PYTHONPATH}:/home/mage_code"
+ENV PYTHONPATH="${PYTHONPATH}:${MAGE_CODE_PATH}"
 
 CMD ["/bin/sh", "-c", "/app/run_app.sh"]


### PR DESCRIPTION
# Summary
I'm not certain, but it seems like a mistake to me that the python path is constant and not change with the ARG `MAGE_CODE_PATH`.