### PR TITLE
Update Dockerfile to use mage_data as the working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mageai/mageai:latest
 
 # Replace default_repo with the name of your project (e.g. demo_project)
 ARG PROJECT_NAME=default_repo
-ARG MAGE_CODE_PATH=/home/src
+ARG MAGE_CODE_PATH=/home/mage_data
 ARG USER_CODE_PATH=${MAGE_CODE_PATH}/${PROJECT_NAME}
 
 # Set the MAGE_CODE_PATH variable to the path of the Mage code.


### PR DESCRIPTION
# Summary
<!-- Brief summary of what your code does -->
The copy-and-pastable recommended Dockerfile here: https://docs.mage.ai/production/ci-cd/local-cloud/repository-setup already has the change to `/home/mage_data`, but the file that is linked in the documentation (this file) doesn't.

There should probably only be one source of truth, but for now this PR keeps both consistent.

# Tests
<!-- How did you test your change? -->

No tests

cc:
<!-- Optionally mention someone to let them know about this pull request -->
@wangxiaoyou1993 as mentioned in the Slack help thread